### PR TITLE
Make sure we ignore banners in ls-remote polling

### DIFF
--- a/src/main/java/hudson/plugins/git/GitAPI.java
+++ b/src/main/java/hudson/plugins/git/GitAPI.java
@@ -1097,6 +1097,11 @@ public class GitAPI implements IGitAPI {
         args.add(remoteRepoUrl);
         args.add(branch);
         String result = launchCommand(args);
+        String[] results = result.split("\n");
+        if(results.length > 0){
+            //if ls-remote returns a banner, we want the last line
+            result = results[results.length-1];
+        }
         return result.length()>=40 ? result.substring(0,40) : "";
     }
 }


### PR DESCRIPTION
If the git server returns banners, then ls-remote here fails to return the correct head revision.
