### PR TITLE
Prevent triggering poll for all repositories when url doesn't match

### DIFF
--- a/src/main/java/hudson/plugins/git/GitStatus.java
+++ b/src/main/java/hudson/plugins/git/GitStatus.java
@@ -226,6 +226,10 @@ public class GitStatus extends AbstractModelObject implements RootAction{
                                 }
                             }
 
+                            if (!repositoryMatches) {
+                                continue;
+                            }
+
                             if (branches.length == 0) {
                                 branchMatches = true;
                             } else {


### PR DESCRIPTION
This PR fixes bug described in http://www.eclipse.org/forums/index.php/mv/msg/488371/1232380/#msg_1232380
