### PR TITLE
Ensure that the clean() call also cleans directories - as per the docs

### DIFF
--- a/src/main/java/hudson/plugins/git/GitAPI.java
+++ b/src/main/java/hudson/plugins/git/GitAPI.java
@@ -259,7 +259,9 @@ public class GitAPI implements IGitAPI {
     public void clean() throws GitException {
         verifyGitRepository();
         try {
-            jGitDelegate.clean().call();
+            jGitDelegate.clean()
+                .setCleanDirectories(true)
+                .call();
         } catch (Exception ex) {
             throw new GitException(ex);
         }  


### PR DESCRIPTION
Proposed change for https://bugs.eclipse.org/bugs/show_bug.cgi?id=396649
